### PR TITLE
TUT-1596 - fix for overflow while parsing floats on 32-bit platform

### DIFF
--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -208,6 +208,16 @@ class JSONParserTests: XCTestCase {
             }
         }
     }
+    
+    func testThatParserHandlesLongFloats() {
+        do {
+            // a bit bigger than max In32 before the decimal point
+            let value = try JSONFromString("2147483649.12").double()
+            XCTAssertEqualWithAccuracy(value, 2147483649.12, accuracy: DBL_EPSILON)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 
     func testParserHandlingOfNumericOverflow() {
         for string in [


### PR DESCRIPTION
This fix uses the approach of using an Int64 to keep the intermediate computation, then converting to native-Int or Float as needed.

This makes behavior consistent on 32-bit vs 64-bit platforms