### PR TITLE
TUT-1596 - fix for overflow while parsing floats on 32-bit platform

### DIFF
--- a/Tests/FreddyTests/JSONParserTests.swift
+++ b/Tests/FreddyTests/JSONParserTests.swift
@@ -229,6 +229,16 @@ class JSONParserTests: XCTestCase {
         }
     }
 
+    func testThatParserHandlesLongFloats() {
+        do {
+            // a bit bigger than max In32 before the decimal point
+            let value = try JSONParser.parse("2147483649.12").getDouble()
+            XCTAssertEqualWithAccuracy(value, 2147483649.12, accuracy: DBL_EPSILON)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
     func testParserHandlingOfNumericOverflow() {
         for string in [
             // Int64.max + 1


### PR DESCRIPTION
This is the swift3 version of the fix